### PR TITLE
fix error: corrigir erro de 'write after end' no middleware de sanitize

### DIFF
--- a/backend/src/middlewares/sanitizedMiddleware.js
+++ b/backend/src/middlewares/sanitizedMiddleware.js
@@ -1,21 +1,30 @@
 const sanitizer = require('perfect-express-sanitizer');
 const xss = require('xss');
 
-const sanitizedMiddleware = (req, res, next) => {
-  sanitizer.clean({
-    xss: true,
-    noSql: true,
-    sql: true,
-  })(req, res, next);
+const sanitizedMiddleware = async (req, res, next) => {
+  try {
+    await new Promise((resolve, reject) => {
+      sanitizer.clean({
+        xss: true,
+        noSql: true,
+        sql: true,
+      })(req, res, (err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
 
-  if (req.body) {
-    req.body = Object.keys(req.body).reduce((acc, key) => {
-      acc[key] = xss(req.body[key]);
-      return acc;
-    }, {});
+    if (req.body) {
+      req.body = Object.keys(req.body).reduce((acc, key) => {
+        acc[key] = xss(req.body[key]);
+        return acc;
+      }, {});
+    }
+
+    next();
+  } catch (err) {
+    next(err); 
   }
-
-  next();
 };
 
 module.exports = sanitizedMiddleware;


### PR DESCRIPTION
- Corrigido o erro de "write after end" no `sanitizedMiddleware`.
- Ajustado o fluxo assíncrono no middleware para garantir que a resposta não seja finalizada antes de concluir a sanitização.
- Utilizado `await` e `Promise` para garantir que a sanitização seja concluída corretamente antes de chamar `next()`.
- Melhorado o controle de fluxo para evitar a escrita na resposta após ela ser finalizada, resolvendo o problema de stream.